### PR TITLE
PHOENIX-5454 scripts start foreground java processes as child processes

### DIFF
--- a/bin/psql.py
+++ b/bin/psql.py
@@ -68,5 +68,4 @@ java_cmd = java + ' $PHOENIX_OPTS ' + \
     os.path.join(phoenix_utils.current_dir, "log4j.properties") + \
     " org.apache.phoenix.util.PhoenixRuntime " + args 
 
-exitcode = subprocess.call(java_cmd, shell=True)
-sys.exit(exitcode)
+os.execl("/bin/sh", "/bin/sh", "-c", java_cmd)

--- a/bin/queryserver.py
+++ b/bin/queryserver.py
@@ -202,6 +202,6 @@ elif command == 'stop':
 else:
     # run in the foreground using defaults from log4j.properties
     cmd = java_cmd % {'java': java, 'root_logger': 'INFO,console', 'log_dir': '.', 'log_file': 'psql.log'}
-    # Because shell=True is not set, we don't have to alter the environment
-    child = subprocess.Popen(cmd.split())
-    sys.exit(child.wait())
+    splitcmd = cmd.split()
+    os.execv(splitcmd[0], splitcmd)
+    

--- a/bin/queryserver.py
+++ b/bin/queryserver.py
@@ -203,5 +203,5 @@ else:
     # run in the foreground using defaults from log4j.properties
     cmd = java_cmd % {'java': java, 'root_logger': 'INFO,console', 'log_dir': '.', 'log_file': 'psql.log'}
     splitcmd = cmd.split()
-    os.execv(splitcmd[0], splitcmd)
+    os.execvp(splitcmd[0], splitcmd)
     

--- a/bin/sqlline-thin.py
+++ b/bin/sqlline-thin.py
@@ -171,5 +171,4 @@ java_cmd = java + ' $PHOENIX_OPTS ' + \
     " --color=" + colorSetting + " --fastConnect=" + args.fastconnect + " --verbose=" + args.verbose + \
     " --incremental=false --isolation=TRANSACTION_READ_COMMITTED " + sqlfile
 
-exitcode = subprocess.call(java_cmd, shell=True)
-sys.exit(exitcode)
+os.execl("/bin/sh", "/bin/sh", "-c", java_cmd)


### PR DESCRIPTION
use os.exec*() in python scripts to start foreground java processes