### PR TITLE
PHOENIX-6398: Returns uniform SQL dialect in calcite for the PQS

### DIFF
--- a/phoenix-queryserver-client/src/main/java/org/apache/phoenix/queryserver/client/Driver.java
+++ b/phoenix-queryserver-client/src/main/java/org/apache/phoenix/queryserver/client/Driver.java
@@ -38,7 +38,7 @@ public class Driver extends org.apache.calcite.avatica.remote.Driver {
         "org-apache-phoenix-remote-jdbc.properties",
         "Phoenix Remote JDBC Driver",
         "unknown version",
-        "Apache Phoenix",
+        "Phoenix",
         "unknown version");
   }
 


### PR DESCRIPTION
# [PHOENIX-6398](https://issues.apache.org/jira/browse/PHOENIX-6398): Returns uniform SQL dialect in calcite for the PQS

## Description

database name in core module
```java
@Override
public String getDatabaseProductName() throws SQLException {
    return "Phoenix";
}
```

database name in PQS module
```java
return DriverVersion.load(
    Driver.class,
    "org-apache-phoenix-remote-jdbc.properties",
    "Phoenix Remote JDBC Driver",
    "unknown version",
    "Apache Phoenix",
    "unknown version");
```

In result, Calcite could not create `PhoenixSqlDialect` for PQS. (org.apache.calcite.sql.SqlDialectFactoryImpl)
```java
case "ORACLE":
  return new OracleSqlDialect(c);
case "PHOENIX":
  return new PhoenixSqlDialect(c);
.....
```

## Documentation
  There are no changes visible to the user.

## Testing
  1. Builded the `phoenix-queryserver-client-[XXX]-SNAPSHOT.jar`
  2. Returns uniform SQL dialect `org.apache.calcite.sql.dialect.PhoenixSqlDialect@1e0b4072`