### PR TITLE
PHOENIX-6463 Include copyPom in maven-repo creation

### DIFF
--- a/phoenix-queryserver-assembly/pom.xml
+++ b/phoenix-queryserver-assembly/pom.xml
@@ -86,6 +86,7 @@
                     <outputDirectory>${project.build.directory}/maven-repo</outputDirectory>
                     <overWriteIfNewer>true</overWriteIfNewer>
                     <useRepositoryLayout>true</useRepositoryLayout>
+                    <copyPom>true</copyPom>
                   </configuration>
                  </execution>
               </executions>


### PR DESCRIPTION
```
$ find phoenix-queryserver-assembly/target/maven-repo
phoenix-queryserver-assembly/target/maven-repo
phoenix-queryserver-assembly/target/maven-repo/org
phoenix-queryserver-assembly/target/maven-repo/org/apache
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/6.0.0-SNAPSHOT
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/6.0.0-SNAPSHOT/phoenix-queryserver-client-6.0.0-SNAPSHOT.jar
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/6.0.0-SNAPSHOT/phoenix-queryserver-client-6.0.0-SNAPSHOT.pom
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/6.0.0-SNAPSHOT/_remote.repositories
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/6.0.0-SNAPSHOT/maven-metadata-local.xml
phoenix-queryserver-assembly/target/maven-repo/org/apache/phoenix/phoenix-queryserver-client/maven-metadata-local.xml
```

The inclusion of the .pom file is what `copyPom=true` enables.