### PR TITLE
PHOENIX-6473 Add Hadoop JMXServlet as /jmx endpoint

### DIFF
--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -207,6 +207,10 @@
       <artifactId>jetty-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -217,10 +221,6 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
     </dependency>
 
     <!-- for tests -->

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -130,10 +130,6 @@
               </filters>
               <relocations>
                 <relocation>
-                  <pattern>org.eclipse.jetty</pattern>
-                  <shadedPattern>${shaded.package}.org.eclipse.jetty</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>javax.servlet</pattern>
                   <shadedPattern>${shaded.package}.javax.servlet</shadedPattern>
                 </relocation>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -222,6 +222,10 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+    </dependency>
 
     <!-- for tests -->
     <dependency>

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/QueryServerOptions.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/QueryServerOptions.java
@@ -37,6 +37,7 @@ public class QueryServerOptions {
     public static final boolean DEFAULT_QUERY_SERVER_CUSTOM_AUTH_ENABLED = false;
     public static final String DEFAULT_QUERY_SERVER_REMOTEUSEREXTRACTOR_PARAM = "doAs";
     public static final boolean DEFAULT_QUERY_SERVER_DISABLE_KERBEROS_LOGIN = false;
+    public static final boolean DEFAULT_QUERY_SERVER_JMXJSONENDPOINT_DISABLED = false;
 
     public static final boolean DEFAULT_QUERY_SERVER_TLS_ENABLED = false;
     //We default to empty *store password

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/QueryServerProperties.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/QueryServerProperties.java
@@ -68,6 +68,8 @@ public class QueryServerProperties {
             "phoenix.queryserver.tls.truststore";
     public static final String QUERY_SERVER_TLS_TRUSTSTORE_PASSWORD =
             "phoenix.queryserver.tls.truststore.password";
+    public static final String QUERY_SERVER_JMX_JSON_ENDPOINT_DISABLED =
+            "phoenix.queryserver.jmxjsonendpoint.disabled";
 
     // keys for load balancer
     public static final String PHOENIX_QUERY_SERVER_LOADBALANCER_ENABLED =

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
@@ -17,6 +17,11 @@
  */
 package org.apache.phoenix.queryserver.server;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.calcite.avatica.server.AvaticaServerConfiguration;
 import org.apache.calcite.avatica.server.ServerCustomizer;
 import org.apache.hadoop.conf.Configuration;
@@ -27,11 +32,6 @@ import org.apache.phoenix.queryserver.server.customizers.JMXJsonEndpointServerCu
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Creates customizers for the underlying Avatica HTTP server.

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
@@ -72,7 +72,10 @@ public interface ServerCustomizersFactory {
                     LOG.warn("Empty value provided for {}, ignoring", QueryServerProperties.CLIENT_JARS_REPO_ATTRIB);
                 }
             }
-            customizers.add(new JMXJsonEndpointServerCustomizer());
+            if (!conf.getBoolean(QueryServerProperties.QUERY_SERVER_JMX_JSON_ENDPOINT_DISABLED,
+                QueryServerOptions.DEFAULT_QUERY_SERVER_JMXJSONENDPOINT_DISABLED)) {
+                customizers.add(new JMXJsonEndpointServerCustomizer());
+            }
             return Collections.unmodifiableList(customizers);
         }
     }

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/ServerCustomizersFactory.java
@@ -17,20 +17,21 @@
  */
 package org.apache.phoenix.queryserver.server;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.calcite.avatica.server.AvaticaServerConfiguration;
 import org.apache.calcite.avatica.server.ServerCustomizer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.phoenix.queryserver.QueryServerOptions;
 import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.queryserver.server.customizers.HostedClientJarsServerCustomizer;
+import org.apache.phoenix.queryserver.server.customizers.JMXJsonEndpointServerCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Creates customizers for the underlying Avatica HTTP server.
@@ -71,6 +72,7 @@ public interface ServerCustomizersFactory {
                     LOG.warn("Empty value provided for {}, ignoring", QueryServerProperties.CLIENT_JARS_REPO_ATTRIB);
                 }
             }
+            customizers.add(new JMXJsonEndpointServerCustomizer());
             return Collections.unmodifiableList(customizers);
         }
     }

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
@@ -1,0 +1,41 @@
+package org.apache.phoenix.queryserver.server.customizers;
+
+import org.apache.calcite.avatica.server.ServerCustomizer;
+import org.apache.hadoop.jmx.JMXJsonServlet;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+public class JMXJsonEndpointServerCustomizer implements ServerCustomizer<Server> {
+  private static final Logger LOG = LoggerFactory.getLogger(JMXJsonEndpointServerCustomizer.class);
+
+  @Override
+  public void customize(Server server) {
+    Handler[] handlers = server.getHandlers();
+    if (handlers.length != 1) {
+      LOG.warn("Observed handlers on server {}", Arrays.toString(handlers));
+      throw new IllegalStateException("Expected to find one handler");
+    }
+    HandlerList list = (HandlerList) handlers[0];
+
+    WebAppContext ctx = new WebAppContext();
+    ctx.setContextPath("/");
+    ServletHolder holder = new ServletHolder(JMXJsonServlet.class);
+    ctx.addServlet(holder, "/jmx");
+
+    ctx.setServer(server);
+
+    Handler[] realHandlers = list.getChildHandlers();
+
+    Handler[] newHandlers = new Handler[realHandlers.length + 1];
+    newHandlers[0] = ctx;
+    System.arraycopy(realHandlers, 0, newHandlers, 1, realHandlers.length);
+    server.setHandler(new HandlerList(newHandlers));
+  }
+}

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
@@ -30,12 +30,12 @@ public class JMXJsonEndpointServerCustomizer implements ServerCustomizer<Server>
     HandlerList list = (HandlerList) handlers[0];
 
     ServletContextHandler ctx = new ServletContextHandler();
-    ctx.setContextPath("/");
+    ctx.setContextPath("/jmx");
     ctx.getServletContext().setAttribute(CONF_CONTEXT_ATTRIBUTE, HBaseConfiguration.create());
 
     Servlet servlet = new JMXJsonServlet();
     ServletHolder holder = new ServletHolder(servlet);
-    ctx.addServlet(holder, "/jmx");
+    ctx.addServlet(holder, "/");
 
     Handler[] realHandlers = list.getChildHandlers();
     Handler[] newHandlers = new Handler[realHandlers.length + 1];

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/customizers/JMXJsonEndpointServerCustomizer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.phoenix.queryserver.server.customizers;
 
 import static org.apache.hadoop.http.HttpServer2.CONF_CONTEXT_ATTRIBUTE;

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/ServerCustomizersTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/ServerCustomizersTest.java
@@ -51,7 +51,7 @@ public class ServerCustomizersTest {
         // the default factory creates an empty list of server customizers
         List<ServerCustomizer<Server>> customizers =
                 queryServer.createServerCustomizers(new Configuration(), avaticaServerConfiguration);
-        Assert.assertEquals(0, customizers.size());
+        Assert.assertEquals(1, customizers.size());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -497,9 +497,9 @@
               <version>${jetty.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.eclipse.jetty</groupId>
-              <artifactId>jetty-webapp</artifactId>
-              <version>${jetty.version}</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,11 @@
               <version>${jetty.version}</version>
             </dependency>
             <dependency>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-webapp</artifactId>
+              <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-client</artifactId>
                 <version>${curator.version}</version>


### PR DESCRIPTION
Added new Avatica server customizer to create `/jmx` endpoint powered by JMXServlet. Also had to add jetty-servlet dependency and remove shading of jetty, otherwise the Servlet class cannot be instantiated.