### PR TITLE
PHOENIX-6484 Python phoenixdb throws error on empty resultsets with a…

### DIFF
--- a/python-phoenixdb/phoenixdb/tests/test_types.py
+++ b/python-phoenixdb/phoenixdb/tests/test_types.py
@@ -350,6 +350,8 @@ class TypesTest(DatabaseTestCase):
     def test_array(self):
         self.createTable("phoenixdb_test_tbl1", "CREATE TABLE {table} (id integer primary key, val integer[])")
         with self.conn.cursor() as cursor:
+            cursor.execute("SELECT id, val FROM phoenixdb_test_tbl1 ORDER BY id")
+            self.assertEqual(cursor.fetchall(), [])
             cursor.execute("UPSERT INTO phoenixdb_test_tbl1 VALUES (1, ARRAY[1, 2])")
             cursor.execute("UPSERT INTO phoenixdb_test_tbl1 VALUES (2, ?)", [[2, 3]])
             cursor.execute("UPSERT INTO phoenixdb_test_tbl1 VALUES (3, ?)", [[4]])

--- a/python-phoenixdb/phoenixdb/types.py
+++ b/python-phoenixdb/phoenixdb/types.py
@@ -221,10 +221,11 @@ JDBC_TO_REP = dict([
     (-16, common_pb2.STRING),  # LONGNVARCHAR
     (2011, common_pb2.STRING),  # NCLOB
     (2009, common_pb2.STRING),  # SQLXML
+    # Returned by Avatica for Arrays in EMPTY resultsets
+    (2000, common_pb2.BYTE_STRING)  # JAVA_OBJECT
     # These are defined by JDBC, but cannot be mapped
     # NULL
     # OTHER
-    # JAVA_OBJECT
     # DISTINCT
     # STRUCT
     # ARRAY 2003 - We are handling this as a special case


### PR DESCRIPTION
…rray types