### PR TITLE
PHOENIX-6614: QueryServerTest fails for hostname upper case letters

### DIFF
--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerTest.java
@@ -40,7 +40,7 @@ public class QueryServerTest {
 
   @BeforeClass
   public static void setupOnce() throws IOException {
-    EXPECTED_HOSTNAME = InetAddress.getLocalHost().getCanonicalHostName();
+    EXPECTED_HOSTNAME = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase();
   }
 
   @Before


### PR DESCRIPTION
QueryServerTest fails on the machine with uppercase letters in hostname:

```
org.junit.ComparisonFailure: 
Expected :HTTP/vitalii-UX331UN@EXAMPLE.COM
Actual   :HTTP/vitalii-ux331un@EXAMPLE.COM 
```
It appears kerberos does not work with hostnames with uppercase characters. The full explanation is in [HADOOP-18047](https://issues.apache.org/jira/browse/HADOOP-18047?focusedCommentId=17459700&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17459700).

So need to use lowercase letters for hostname in this test to make them passing.

