### PR TITLE
PHOENIX-6613 QueryServerBasicsIT usage by external tools

### DIFF
--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerBasicsIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerBasicsIT.java
@@ -395,4 +395,8 @@ public class QueryServerBasicsIT extends BaseTest {
       System.out.flush();
       Thread.sleep(24*60*60*1000);
   }
+
+  public static String getConnString() {
+    return CONN_STRING;
+  }
 }

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/TlsUtil.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/TlsUtil.java
@@ -54,7 +54,7 @@ public class TlsUtil {
     protected static final File KEYSTORE = new File(TARGET_DIR, "avatica-test-ks.jks");
     protected static final File TRUSTSTORE = new File(TARGET_DIR, "avatica-test-ts.jks");
 
-    private static final Logger LOG = LoggerFactory.getLogger(QueryServerBasicsIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TlsUtil.class);
 
     public static File getTrustStoreFile() {
         return TRUSTSTORE;

--- a/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/QueryServer.java
+++ b/phoenix-queryserver/src/main/java/org/apache/phoenix/queryserver/server/QueryServer.java
@@ -340,12 +340,10 @@ public final class QueryServer extends Configured implements Tool, Runnable {
    * the configured principal as-is if {@code _HOST} is not the "instance".
    */
   String getSpnegoPrincipal(Configuration conf) throws IOException {
-    String httpPrincipal = conf.get(
-        QueryServerProperties.QUERY_SERVER_KERBEROS_HTTP_PRINCIPAL_ATTRIB, null);
+    String httpPrincipal = conf.get(QueryServerProperties.QUERY_SERVER_KERBEROS_HTTP_PRINCIPAL_ATTRIB, null);
     // Backwards compat for a configuration key change
     if (httpPrincipal == null) {
-      httpPrincipal = conf.get(
-          QueryServerProperties.QUERY_SERVER_KERBEROS_HTTP_PRINCIPAL_ATTRIB_LEGACY, null);
+      httpPrincipal = conf.get(QueryServerProperties.QUERY_SERVER_KERBEROS_HTTP_PRINCIPAL_ATTRIB_LEGACY, null);
     }
 
     String hostname = Strings.domainNamePointerToHostName(DNS.getDefaultHost(


### PR DESCRIPTION
QueryServerBasicsIT is a public class which can allow testing PQS in external tools.
It is possible to setup PQS, but there is no possibility to connect to it withDriverManager.getConnection(CONN_STRING), because there is no getter for CONN_STRING.