### PR TITLE
Remove phoenixdb error messages on exit

### DIFF
--- a/python-phoenixdb/phoenixdb/connection.py
+++ b/python-phoenixdb/phoenixdb/connection.py
@@ -56,8 +56,12 @@ class Connection(object):
         self.set_session(**avatica_props_init)
 
     def __del__(self):
-        if not self._closed:
-            self.close()
+        try:
+            if not self._closed:
+                self.close()
+        except ImportError:
+            # Pass if Python is shutting down when this is called
+            pass
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## Background
If you open a connection and then `sys.exit()` or ctrl+D, you will always get this message from connections not being able to be closed from the `__del__` method in `connection.py`.

```
Exception ignored in: <function Connection.__del__ at 0x102eeb280>
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/phoenixdb/connection.py", line 60, in __del__
  File "/usr/local/lib/python3.9/site-packages/phoenixdb/connection.py", line 114, in close
  File "/usr/local/lib/python3.9/site-packages/phoenixdb/avatica/client.py", line 397, in close_connection
  File "/usr/local/lib/python3.9/site-packages/phoenixdb/avatica/client.py", line 218, in _apply
  File "/usr/local/lib/python3.9/site-packages/phoenixdb/avatica/client.py", line 188, in _post_request
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 590, in post
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 532, in request
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 711, in merge_environment_settings
  File "/usr/local/lib/python3.9/site-packages/requests/utils.py", line 797, in get_environ_proxies
  File "/usr/local/lib/python3.9/site-packages/requests/utils.py", line 781, in should_bypass_proxies
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/urllib/request.py", line 2647, in proxy_bypass
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/urllib/request.py", line 2624, in proxy_bypass_macosx_sysconf
  File "/usr/local/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/urllib/request.py", line 2566, in _proxy_bypass_macosx_sysconf
ImportError: sys.meta_path is None, Python is likely shutting down
```

## To Test
Testing was completed by running two steps:
1. Running `del` on an open connection successfully closes conns.
2. Exiting Python does not print a long error message to stdout.