### PR TITLE
PHOENIX-6861 PQS fails to start because of relocated javax.servlet wi…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B clean install
+      run: mvn -B clean install -Pshade-javax-servlet

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,14 +26,26 @@ Copyright ©2020 [Apache Software Foundation](http://www.apache.org/). All Right
 This repository will build a tarball which is capable of running the Phoenix Query Server.
 
 By default, this tarball does not contain a Phoenix client jar as it is meant to be agnostic
-of Phoenix version (one PQS release can be used against any Phoenix version). Today, PQS builds against
-the Phoenix 5.1.1 release with HBase 2.4.2.
+of Phoenix version (one PQS release should be usable against any Phoenix version).
+
+However, due to an incompatible change in the relocations used in the phoenix-client JAR, you need to build
+Phoenix Query Server with the `shade-javax-servlet` maven profile if you use Phoenix versions
+5.1.1, 5.1.2, 5.1.3 or 4.16.x with it. (See PHOENIX-6861 for more details)
+This applies whether you bundle the Phoenix client into the assembly or add it separately.
+Phoenix 5.2.0 and later requires that PQS is built WITHOUT the `shade-javax-servlet` maven profile.
 
 In order to use Phoenix Query Server, you need to copy the phoenix-client-embedded jar appropriate
 for your cluster into the Queryserver root directory.
 
 Note that the resulting Query Server binaries are not tied to any Phoenix, Hbase or Hadoop versions,
-The current release requires at least Phoenix 4.16.0 or 5.1.0.
+apart from the exception above.
+
+
+```
+$ mvn clean package -Pshade-javax-servlet
+```
+
+For other Phoenix versions build with the default settings
 
 ```
 $ mvn clean package
@@ -47,7 +59,7 @@ the `phoenix.client.artifactid` to choose the phoenix-client HBase variant.
 You need to bundle the embedded client variant, to avoid conflicts with the logging libraries.
 
 ```
-$ mvn clean package -Dpackage.phoenix.client -Dphoenix.version=5.1.1 -Dphoenix.client.artifactid=phoenix-client-embedded-hbase-2.4 -pl '!phoenix-queryserver-it'
+$ mvn clean package -Dpackage.phoenix.client -Dphoenix.version=5.1.1 -Dphoenix.client.artifactid=phoenix-client-embedded-hbase-2.4 -Pshade-javax-servlet -pl '!phoenix-queryserver-it'
 ```
 
 ### Running integration tests

--- a/phoenix-queryserver-it/pom.xml
+++ b/phoenix-queryserver-it/pom.xml
@@ -192,5 +192,15 @@
       <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
+        <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -38,6 +38,7 @@
   <properties>
     <top.dir>${project.basedir}/..</top.dir>
     <shaded.package>org.apache.phoenix.shaded</shaded.package>
+    <javax.servlet.package>dummy.disable.shading</javax.servlet.package>
   </properties>
 
   <build>
@@ -130,8 +131,8 @@
               </filters>
               <relocations>
                 <relocation>
-                  <pattern>javax.servlet</pattern>
-                  <shadedPattern>${shaded.package}.javax.servlet</shadedPattern>
+                  <pattern>${javax.servlet.package}</pattern>
+                  <shadedPattern>${shaded.package}.${javax.servlet.package}</shadedPattern>
                 </relocation>
                 <!-- Calcite/Avatica is not relocated because the wire API (as of <=1.8.0) expects
                      consistent class names on client and server. Relocating these would break
@@ -245,4 +246,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <!-- This is required for operation with Phoenix 5.1.0 - 5.1.3 and 4.16.x -->
+      <!-- See PHOENIX-6861 -->
+      <id>shade-javax-servlet</id>
+      <activation>
+        <property>
+          <name>shade-javax-servlet</name>
+        </property>
+      </activation>
+      <properties>
+        <javax.servlet.package>javax.servlet</javax.servlet.package>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,12 @@
         <!-- General Properties -->
         <top.dir>${project.basedir}</top.dir>
 
-        <phoenix.version>5.1.1</phoenix.version>
+        <phoenix.version>5.1.3</phoenix.version>
 
         <!-- Hadoop/Hbase Versions -->
-        <hbase.version>2.4.2</hbase.version>
+        <hbase.version>2.4.15</hbase.version>
         <hadoop.version>3.1.4</hadoop.version>
-        <phoenix.client.artifactid>phoenix-client-hbase-2.4</phoenix.client.artifactid>
+        <phoenix.client.artifactid>phoenix-client-embedded-hbase-2.4</phoenix.client.artifactid>
 
         <!-- Dependency versions -->
         <zookeeper.version>3.5.8</zookeeper.version>
@@ -89,6 +89,7 @@
         <avatica.version>1.23.0</avatica.version>
         <servlet.api.version>3.1.0</servlet.api.version>
         <jsr305.version>3.0.0</jsr305.version>
+        <log4j2.version>2.19.0</log4j2.version>
 
         <!-- Test Dependency versions -->
         <mockito-all.version>1.8.5</mockito-all.version>
@@ -691,6 +692,16 @@
                 <artifactId>bcprov-jdk15</artifactId>
                 <version>140</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j2.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…th Phoenix 5.2

- make javax.servlet relocation a build time option controlled by a profile
- update default phoenix version to 5.1.3 and HBase to 2.4.12
- add log4j2 logging test dependencies so that tests can be run with HBase 2.5