### PR TITLE
PHOENIX-6917: Added support for getting CoulmnLabel rather than the CoulmnName

### DIFF
--- a/python-phoenixdb/phoenixdb/cursor.py
+++ b/python-phoenixdb/phoenixdb/cursor.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # TODO see note in Cursor.rowcount()
 MAX_INT = 2 ** 64 - 1
 
-ColumnDescription = collections.namedtuple('ColumnDescription', 'name type_code display_size internal_size precision scale null_ok')
+ColumnDescription = collections.namedtuple('ColumnDescription', 'label type_code display_size internal_size precision scale null_ok')
 """Named tuple for representing results from :attr:`Cursor.description`."""
 
 
@@ -115,7 +115,7 @@ class Cursor(object):
         description = []
         for column in self._signature.columns:
             description.append(ColumnDescription(
-                column.column_name,
+                column.label,
                 column.type.name,
                 column.display_size,
                 None,

--- a/python-phoenixdb/phoenixdb/cursor.py
+++ b/python-phoenixdb/phoenixdb/cursor.py
@@ -386,5 +386,5 @@ class DictCursor(Cursor):
         row = super(DictCursor, self)._transform_row(row)
         d = {}
         for ind, val in enumerate(row):
-            d[self._signature.columns[ind].column_name] = val
+            d[self._signature.columns[ind].label] = val
         return d

--- a/python-phoenixdb/phoenixdb/cursor.py
+++ b/python-phoenixdb/phoenixdb/cursor.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # TODO see note in Cursor.rowcount()
 MAX_INT = 2 ** 64 - 1
 
-ColumnDescription = collections.namedtuple('ColumnDescription', 'label type_code display_size internal_size precision scale null_ok')
+ColumnDescription = collections.namedtuple('ColumnDescription', 'name type_code display_size internal_size precision scale null_ok')
 """Named tuple for representing results from :attr:`Cursor.description`."""
 
 

--- a/python-phoenixdb/phoenixdb/tests/dbapi20.py
+++ b/python-phoenixdb/phoenixdb/tests/dbapi20.py
@@ -74,7 +74,7 @@ class DatabaseAPI20Test(unittest.TestCase):
     insert = 'insert'
 
     lowerfunc = 'lower' # Name of stored procedure to convert string->lowercase
-        
+
     # Some drivers may need to override these helpers, for example adding
     # a 'commit' after the execute.
     def executeDDL1(self,cursor):
@@ -208,7 +208,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 con.rollback()
             except self.driver.NotSupportedError:
                 pass
-    
+
     def test_cursor(self):
         con = self._connect()
         try:
@@ -399,12 +399,12 @@ class DatabaseAPI20Test(unittest.TestCase):
         trouble = "thi%s :may ca%(u)se? troub:1e"
         self.assertEqual(res[0][1], trouble,
             'cursor.fetchall retrieved incorrect data, or data inserted '
-            'incorrectly. Got=%s, Expected=%s' % (repr(res[0][1]), repr(trouble)))      
+            'incorrectly. Got=%s, Expected=%s' % (repr(res[0][1]), repr(trouble)))
         self.assertEqual(res[1][1], trouble,
             'cursor.fetchall retrieved incorrect data, or data inserted '
             'incorrectly. Got=%s, Expected=%s' % (repr(res[1][1]), repr(trouble)
             ))
-        
+
     def test_executemany(self):
         con = self._connect()
         try:
@@ -575,7 +575,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.assertEqual(len(rows),6)
             rows = [r[0] for r in rows]
             rows.sort()
-          
+
             # Make sure we get the right data back out
             for i in range(0,6):
                 self.assertEqual(rows[i],self.samples[i],
@@ -646,10 +646,10 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.fetchall should return an empty list if '
                 'a select query returns no rows'
                 )
-            
+
         finally:
             con.close()
-    
+
     def test_mixedfetch(self):
         con = self._connect()
         try:
@@ -832,3 +832,18 @@ class DatabaseAPI20Test(unittest.TestCase):
         self.assertTrue(hasattr(self.driver,'ROWID'),
             'module.ROWID must be defined.'
             )
+
+    # https://issues.apache.org/jira/browse/PHOENIX-6917
+    def test_alias(self):
+        con = self._connect()
+        try:
+            cur = con.cursor()
+            self.executeDDL2(cur)
+            cur.execute("CREATE TABLE IF NOT EXISTS STOCK_SYMBOL (SYMBOL VARCHAR NOT NULL PRIMARY KEY, COMPANY VARCHAR)")
+            cur.execute("UPSERT INTO STOCK_SYMBOL VALUES ('CRM','SALESFORCE')")
+            cur.execute("UPSERT INTO STOCK_SYMBOL VALUES ('AAPL','APPLE Inc')")
+            cur.execute("SELECT symbol as symb, company as comp FROM STOCK_SYMBOL")
+            self.assertEqual(cur.description[0][0], 'SYMB')
+            self.assertEqual(cur.description[1][0], 'COMP')
+        finally:
+            con.close()


### PR DESCRIPTION
 * Added support  for getting the columnLabel (the “as name”) rather than the columnName with a cursor.

Below is the example

```
calcite 💎:sql> select c1 as hello, c2 as world from int_tbl;
+-------------+-------------+
| c1          | c2          |
|-------------+-------------|
| 5           | 0           |
| -123        | 123         |
| 1           | 123456      |
| -123456     | -123456     |
| 10          | 50          |
| -2147483648 | 1           |
| 2147483647  | -2147483648 |
| <null>      | 10          |
| <null>      | <null>      |
| 1           | 1           |
+-------------+-------------+

```
with this patch i'm able to get column_name as column label

```
calcite 💎:sql> select c1 as hello, c2 as world from int_tbl;

+-------------+-------------+
|       HELLO |       WORLD |
|-------------+-------------|
|           5 |           0 |
|        -123 |         123 |
|           1 |      123456 |
|     -123456 |     -123456 |
|          10 |          50 |
| -2147483648 |           1 |
|  2147483647 | -2147483648 |
|             |          10 |
|             |             |
|           1 |           1 |
+-------------+-------------+
```