### PR TITLE
PHOENIX-6924 Bump Junit, Jetty and Gson to the latest versions in que…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <zookeeper.version>3.5.8</zookeeper.version>
         <curator.version>2.12.0</curator.version>
 
-        <gson.version>2.2.4</gson.version>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <gson.version>2.10.1</gson.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <sqlline.version>1.9.0</sqlline.version>
@@ -93,7 +93,7 @@
 
         <!-- Test Dependency versions -->
         <mockito-all.version>1.8.5</mockito-all.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
 
         <!-- Plugin versions -->
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>


### PR DESCRIPTION
…ryserver

Jetty: 9.4.51.v20230217
Gson: 2.10.1
Junit: 4.13.1