### PR TITLE
PHOENIX-7125 PQS tests fail when hbase-shaded-netty version used by m…

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -67,11 +67,23 @@ $ mvn clean package -Dpackage.phoenix.client -Dphoenix.version=5.1.1 -Dphoenix.c
 `mvn package` will run the unit tests while building, but it will not run the integration test suite.
 
 The integration tests will run with the default Phoenix and HBase version.
-Running the integration tests with non-default Phoenix and HBase versions is not supported.
+Running the integration tests with non-default Phoenix and HBase versions may or may not work.
 
 ```
 $ mvn clean verify
 ```
+
+
+If a different Phoenix version is used for testing, then at least the *hbase.version*
+and *hadoop.version* properties must be set to the versions used to build phoenix-client-embdedd,
+but other changes may also be needed, or there may be un-resolvable conflicts.
+
+```
+$ mvn clean verify -Dphoenix.version=5.1.3 -Pshade-javax-servlet -Dphoenix.client.artifactid=phoenix-client-embedded-hbase-2.4 -Dhadoop.version=3.1.3 -Dhbase.version=2.4.15  -DforkCount=6'
+```
+
+(At the time of writing, the above will run, but fail because 5.1.3 does not have PHOENIX-5066
+required by the failing test)
 
 ### Running project reports
 

--- a/pom.xml
+++ b/pom.xml
@@ -1072,6 +1072,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -1095,6 +1099,10 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1120,6 +1128,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -1135,6 +1147,10 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1155,6 +1171,10 @@
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -1207,6 +1227,10 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
…inicluster does not match the version in phoenix-client

update BUILDING.md
add missing org.slf4j:slf4j-log4j12 exclusions to Hadoop test dependencies