### PR TITLE
PHOENIX-7404 Build the HBase 2.5+ profile with Hadoop 3.3.6 and bump Phoenix to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <!-- Hadoop/Hbase Versions -->
         <hbase.version>2.5.10-hadoop3</hbase.version>
-        <hadoop.version>3.3.6</hadoop.version>
+        <hadoop.version>3.2.4</hadoop.version>
         <phoenix.client.artifactid>phoenix-client-embedded-hbase-2.5</phoenix.client.artifactid>
 
         <!-- Dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,11 @@
         <top.dir>${project.basedir}</top.dir>
         <test.tmp.dir>${project.build.directory}</test.tmp.dir>
 
-        <phoenix.version>5.2.0</phoenix.version>
+        <phoenix.version>5.2.1</phoenix.version>
 
         <!-- Hadoop/Hbase Versions -->
-        <hbase.version>2.5.8-hadoop3</hbase.version>
-        <hadoop.version>3.2.4</hadoop.version>
+        <hbase.version>2.5.10-hadoop3</hbase.version>
+        <hadoop.version>3.3.6</hadoop.version>
         <phoenix.client.artifactid>phoenix-client-embedded-hbase-2.5</phoenix.client.artifactid>
 
         <!-- Dependency versions -->


### PR DESCRIPTION
This will let us be up to date with the Phoenix latest supported version as well as with latest HBase 2.5.10
This PR addresses [PHOENIX-7404](https://issues.apache.org/jira/browse/PHOENIX-7404).