### PR TITLE
PHOENIX-7780: Update jUnit to 5.10 in pom.xml files

### DIFF
--- a/phoenix-queryserver-it/pom.xml
+++ b/phoenix-queryserver-it/pom.xml
@@ -124,8 +124,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phoenix-queryserver-load-balancer/pom.xml
+++ b/phoenix-queryserver-load-balancer/pom.xml
@@ -127,8 +127,8 @@
 
     <!-- for tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phoenix-queryserver-orchestrator/pom.xml
+++ b/phoenix-queryserver-orchestrator/pom.xml
@@ -96,8 +96,8 @@
         </dependency>
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -232,8 +232,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <!-- Test Dependency versions -->
         <testng.version>6.10</testng.version>
         <mockito.version>4.11.0</mockito.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>5.10.2</junit.version>
 
         <!-- Plugin versions -->
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
@@ -1207,10 +1207,15 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <ignoredDependencies>
+                            <ignoredDependency>junit:junit:jar:4.13.2</ignoredDependency>
+                            <ignoredDependency>org.junit.vintage:junit-vintage-engine:jar:5.10.2</ignoredDependency>
+                        </ignoredDependencies>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>enforce-dependencies</id>


### PR DESCRIPTION
First sub-task of [PHOENIX-7779](https://issues.apache.org/jira/browse/PHOENIX-7779): Update jUnit to 5.10. Updating pom files to jUnit to 5.10.2 without code changes.