### PR TITLE
PHOENIX-7779: move phoenix-queryserver to jUnit5.

### DIFF
--- a/phoenix-queryserver-it/pom.xml
+++ b/phoenix-queryserver-it/pom.xml
@@ -79,6 +79,10 @@
         <configuration>
           <!-- dependency:analyze is quite useless for hadoop test dependencies -->
           <ignoreNonCompile>true</ignoreNonCompile>
+          <!-- Engine is required at test runtime by Surefire; not referenced from test sources -->
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
     </plugins>
@@ -123,11 +127,23 @@
       <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>

--- a/phoenix-queryserver-it/src/it/bin/test_phoenixdb.sh
+++ b/phoenix-queryserver-it/src/it/bin/test_phoenixdb.sh
@@ -48,9 +48,7 @@ shift 5
 
 PY_ENV_PATH=$( mktemp -d )
 
-#virtualenv $PY_ENV_PATH
-python -m venv "$PY_ENV_PATH"
-python --version
+virtualenv $PY_ENV_PATH
 
 pushd ${PY_ENV_PATH}/bin
 
@@ -62,8 +60,7 @@ popd
 
 set -u
 echo "INSTALLING COMPONENTS"
-echo ${LOCAL_PY}
-pip3 install -e file:///${LOCAL_PY}/
+pip install -e file:///${LOCAL_PY}/
 
 export KRB5_CONFIG=$KRB5_CFG_FILE
 cat $KRB5_CONFIG

--- a/phoenix-queryserver-it/src/it/bin/test_phoenixdb.sh
+++ b/phoenix-queryserver-it/src/it/bin/test_phoenixdb.sh
@@ -48,7 +48,9 @@ shift 5
 
 PY_ENV_PATH=$( mktemp -d )
 
-virtualenv $PY_ENV_PATH
+#virtualenv $PY_ENV_PATH
+python -m venv "$PY_ENV_PATH"
+python --version
 
 pushd ${PY_ENV_PATH}/bin
 
@@ -60,7 +62,8 @@ popd
 
 set -u
 echo "INSTALLING COMPONENTS"
-pip install -e file:///${LOCAL_PY}/
+echo ${LOCAL_PY}
+pip3 install -e file:///${LOCAL_PY}/
 
 export KRB5_CONFIG=$KRB5_CFG_FILE
 cat $KRB5_CONFIG

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/HttpParamImpersonationQueryServerIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/HttpParamImpersonationQueryServerIT.java
@@ -16,10 +16,10 @@
  */
 package org.apache.phoenix.end2end;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.security.PrivilegedExceptionAction;
@@ -44,17 +44,14 @@ import org.apache.phoenix.jdbc.PhoenixDatabaseMetaData;
 import org.apache.phoenix.queryserver.QueryServerOptions;
 import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.queryserver.client.Driver;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(Parameterized.class)
-@Category(NeedsOwnMiniClusterTest.class)
+@Tag("NeedsOwnMiniClusterTest")
 public class HttpParamImpersonationQueryServerIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpParamImpersonationQueryServerIT.class);
@@ -67,12 +64,7 @@ public class HttpParamImpersonationQueryServerIT {
         PhoenixDatabaseMetaData.SYSTEM_SEQUENCE_HBASE_TABLE_NAME,
         PhoenixDatabaseMetaData.SYSTEM_STATS_HBASE_TABLE_NAME);
 
-    @Parameters(name = "tls = {0}")
-    public static synchronized Iterable<Boolean> data() {
-        return Arrays.asList(new Boolean[] {false, true});
-    }
-
-    public HttpParamImpersonationQueryServerIT(Boolean tls) throws Exception {
+    public void restartEnvironmentForTls(Boolean tls) throws Exception {
         //Clean up previous environment if any (Junit 4.13 @BeforeParam / @AfterParam would be an alternative)
         if(environment != null) {
             stopEnvironment();
@@ -90,7 +82,7 @@ public class HttpParamImpersonationQueryServerIT {
         environment = new QueryServerEnvironment(conf, 2, tls);
     }
 
-    @AfterClass
+    @AfterAll
     public static synchronized void stopEnvironment() throws Exception {
         environment.stop();
     }
@@ -106,8 +98,10 @@ public class HttpParamImpersonationQueryServerIT {
         }
     }
 
-    @Test
-    public void testSuccessfulImpersonation() throws Exception {
+    @ParameterizedTest(name = "tls = {0}")
+    @ValueSource(booleans = { false, true })
+    public void testSuccessfulImpersonation(Boolean tls) throws Exception {
+        restartEnvironmentForTls(tls);
         final Entry<String,File> user1 = environment.getUser(1);
         final Entry<String,File> user2 = environment.getUser(2);
         // Build the JDBC URL by hand with the doAs
@@ -139,8 +133,10 @@ public class HttpParamImpersonationQueryServerIT {
         });
     }
 
-    @Test
-    public void testDisallowedImpersonation() throws Exception {
+    @ParameterizedTest(name = "tls = {0}")
+    @ValueSource(booleans = { false, true })
+    public void testDisallowedImpersonation(Boolean tls) throws Exception {
+        restartEnvironmentForTls(tls);
         final Entry<String,File> user2 = environment.getUser(2);
         // Build the JDBC URL by hand with the doAs
         final String doAsUrlTemplate = getUrlTemplate();
@@ -209,10 +205,10 @@ public class HttpParamImpersonationQueryServerIT {
             LOG.debug("Caught expected exception", e);
             // Avatica doesn't re-create new exceptions across the wire. Need to just look at the contents of the message.
             String errorMessage = e.getMessage();
-            assertTrue("Expected the error message to contain an HBase AccessDeniedException", errorMessage.contains("org.apache.hadoop.hbase.security.AccessDeniedException"));
+            assertTrue(errorMessage.contains("org.apache.hadoop.hbase.security.AccessDeniedException"),"Expected the error message to contain an HBase AccessDeniedException");
             // Expecting an error message like: "Insufficient permissions for user 'user1' (table=POSITIVE_IMPERSONATION, action=READ)"
             // Being overly cautious to make sure we don't inadvertently pass the test due to permission errors on phoenix system tables.
-            assertTrue("Expected message to contain " + tableName + " and READ", errorMessage.contains(tableName) && errorMessage.contains("READ"));
+            assertTrue(errorMessage.contains(tableName) && errorMessage.contains("READ"),"Expected message to contain " + tableName + " and READ");
         }
     }
 

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerBasicsIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerBasicsIT.java
@@ -22,11 +22,12 @@ import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_CAT;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_CATALOG;
 import static org.apache.phoenix.jdbc.PhoenixDatabaseMetaData.TABLE_SCHEM;
 import static org.apache.phoenix.query.QueryConstants.SYSTEM_SCHEMA_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Method;
 import java.sql.Array;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -39,20 +40,16 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.util.ReadOnlyProps;
 import org.apache.phoenix.util.ThinClientUtil;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,10 +64,8 @@ public class QueryServerBasicsIT extends BaseTest {
   private static Configuration CONF;
   private static String CONN_STRING;
 
-  @Rule
-  public TestName name = new TestName();
 
-  @BeforeClass
+  @BeforeAll
   public static synchronized void doSetup() throws Exception {
       setUpTestDriver(ReadOnlyProps.EMPTY_PROPS);
 
@@ -89,7 +84,7 @@ public class QueryServerBasicsIT extends BaseTest {
       LOG.info("JDBC connection string is " + CONN_STRING);
   }
 
-  @AfterClass
+  @AfterAll
   public static synchronized void afterClass() throws Exception {
     if (AVATICA_SERVER != null) {
       AVATICA_SERVER.join(TimeUnit.MINUTES.toMillis(1));
@@ -97,8 +92,8 @@ public class QueryServerBasicsIT extends BaseTest {
       if (t != null) {
         fail("query server threw. " + t.getMessage());
       }
-      assertEquals("query server didn't exit cleanly", 0, AVATICA_SERVER.getQueryServer()
-        .getRetCode());
+      assertEquals(0, AVATICA_SERVER.getQueryServer()
+        .getRetCode(),"query server didn't exit cleanly");
     }
   }
 
@@ -108,7 +103,7 @@ public class QueryServerBasicsIT extends BaseTest {
       assertFalse(connection.isClosed());
       try (final ResultSet resultSet = connection.getMetaData().getCatalogs()) {
         final ResultSetMetaData metaData = resultSet.getMetaData();
-        assertFalse("unexpected populated resultSet", resultSet.next());
+        assertFalse(resultSet.next(),"unexpected populated resultSet");
         assertEquals(1, metaData.getColumnCount());
         assertEquals(TABLE_CAT, metaData.getColumnLabel(1));
       }
@@ -124,7 +119,7 @@ public class QueryServerBasicsIT extends BaseTest {
       assertFalse(connection.isClosed());
       try (final ResultSet resultSet = connection.getMetaData().getSchemas()) {
         final ResultSetMetaData metaData = resultSet.getMetaData();
-        assertTrue("unexpected empty resultset", resultSet.next());
+        assertTrue(resultSet.next(),"unexpected empty resultset");
         assertEquals(2, metaData.getColumnCount());
         assertEquals(TABLE_SCHEM, metaData.getColumnLabel(1));
         assertEquals(TABLE_CATALOG, metaData.getColumnLabel(2));
@@ -132,14 +127,14 @@ public class QueryServerBasicsIT extends BaseTest {
         do {
           if (resultSet.getString(1).equalsIgnoreCase(SYSTEM_SCHEMA_NAME)) containsSystem = true;
         } while (resultSet.next());
-        assertTrue(format("should contain at least %s schema.", SYSTEM_SCHEMA_NAME), containsSystem);
+        assertTrue(containsSystem, format("should contain at least %s schema.", SYSTEM_SCHEMA_NAME));
       }
     }
   }
 
   @Test
-  public void smokeTest() throws Exception {
-    final String tableName = name.getMethodName();
+  public void smokeTest(TestInfo testInfo) throws Exception {
+    final String tableName = testInfo.getTestMethod().map(Method::getName).orElseThrow(IllegalStateException::new);
     try (final Connection connection = DriverManager.getConnection(CONN_STRING)) {
       assertFalse(connection.isClosed());
       connection.setAutoCommit(true);
@@ -180,8 +175,8 @@ public class QueryServerBasicsIT extends BaseTest {
   }
 
   @Test
-  public void arrayTest() throws Exception {
-      final String tableName = name.getMethodName();
+  public void arrayTest(TestInfo testInfo) throws Exception {
+      final String tableName = testInfo.getTestMethod().map(Method::getName).orElseThrow(IllegalStateException::new);
       try (Connection conn = DriverManager.getConnection(CONN_STRING);
               Statement stmt = conn.createStatement()) {
           conn.setAutoCommit(false);
@@ -213,7 +208,8 @@ public class QueryServerBasicsIT extends BaseTest {
                   assertEquals(i, Integer.parseInt(rs.getString(1)));
                   Array array = rs.getArray(2);
                   Object untypedArrayData = array.getArray();
-                  assertTrue("Expected array data to be an int array, but was " + untypedArrayData.getClass(), untypedArrayData instanceof Object[]);
+                  assertTrue(untypedArrayData instanceof Object[],
+                          "Expected array data to be an int array, but was " + untypedArrayData.getClass());
                   Object[] arrayData = (Object[]) untypedArrayData;
                   int expectedArrayLength = i % 2 == 0 ? numEvenElements : numOddElements;
                   assertEquals(expectedArrayLength, arrayData.length);
@@ -227,8 +223,8 @@ public class QueryServerBasicsIT extends BaseTest {
   }
 
   @Test
-  public void preparedStatementArrayTest() throws Exception {
-      final String tableName = name.getMethodName();
+  public void preparedStatementArrayTest(TestInfo testInfo) throws Exception {
+      final String tableName = testInfo.getTestMethod().map(Method::getName).orElseThrow(IllegalStateException::new);
       try (Connection conn = DriverManager.getConnection(CONN_STRING);
               Statement stmt = conn.createStatement()) {
           conn.setAutoCommit(false);
@@ -261,7 +257,8 @@ public class QueryServerBasicsIT extends BaseTest {
                   assertEquals(i, Integer.parseInt(rs.getString(1)));
                   Array array = rs.getArray(2);
                   Object untypedArrayData = array.getArray();
-                  assertTrue("Expected array data to be an int array, but was " + untypedArrayData.getClass(), untypedArrayData instanceof Object[]);
+                  assertTrue(untypedArrayData instanceof Object[],
+                          "Expected array data to be an int array, but was " + untypedArrayData.getClass());
                   Object[] arrayData = (Object[]) untypedArrayData;
                   int expectedArrayLength = i % 2 == 0 ? numEvenElements : numOddElements;
                   assertEquals(expectedArrayLength, arrayData.length);
@@ -275,8 +272,8 @@ public class QueryServerBasicsIT extends BaseTest {
   }
 
   @Test
-  public void preparedStatementVarcharArrayTest() throws Exception {
-      final String tableName = name.getMethodName();
+  public void preparedStatementVarcharArrayTest(TestInfo testInfo) throws Exception {
+      final String tableName = testInfo.getTestMethod().map(Method::getName).orElseThrow(IllegalStateException::new);
       try (Connection conn = DriverManager.getConnection(CONN_STRING);
               Statement stmt = conn.createStatement()) {
           conn.setAutoCommit(false);
@@ -309,7 +306,8 @@ public class QueryServerBasicsIT extends BaseTest {
                   assertEquals(i, Integer.parseInt(rs.getString(1)));
                   Array array = rs.getArray(2);
                   Object untypedArrayData = array.getArray();
-                  assertTrue("Expected array data to be an int array, but was " + untypedArrayData.getClass(), untypedArrayData instanceof Object[]);
+                  assertTrue(untypedArrayData instanceof Object[],
+                          "Expected array data to be an int array, but was " + untypedArrayData.getClass());
                   Object[] arrayData = (Object[]) untypedArrayData;
                   int expectedArrayLength = i % 2 == 0 ? numEvenElements : numOddElements;
                   assertEquals(expectedArrayLength, arrayData.length);
@@ -381,7 +379,8 @@ public class QueryServerBasicsIT extends BaseTest {
         ResultSet rs = stmt.executeQuery("select * from " + tableName);
         assertTrue(rs.next());
         LocalDateTime fromDB = rs.getTimestamp("i").toLocalDateTime();
-        assertTrue("Timestamps do not match. inserted:" + now.toString() + " returned:" + fromDB.toString(), fromDB.compareTo(now) == 0);
+        assertTrue(fromDB.compareTo(now) == 0,
+                "Timestamps do not match. inserted:" + now.toString() + " returned:" + fromDB.toString());
       }
     }
   }
@@ -389,7 +388,7 @@ public class QueryServerBasicsIT extends BaseTest {
   @Test
   //Quick and dirty way start up a local Phoenix+PQS instance for testing against
   public void startLocalPQS() throws Exception {
-      Assume.assumeNotNull(System.getProperty("start.unsecure.pqs"));
+      Assumptions.assumeTrue(System.getProperty("start.unsecure.pqs") != null);
       System.out.println("CONN STRING:" + CONN_STRING);
       System.out.println("Tests suspended!!!");
       System.out.println("Kill maven run to stop server");

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerEnvironment.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/QueryServerEnvironment.java
@@ -11,8 +11,8 @@
 package org.apache.phoenix.end2end;
 
 import static org.apache.hadoop.hbase.HConstants.HBASE_DIR;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -137,7 +137,7 @@ public class QueryServerEnvironment {
     }
 
     private void createUsers(int numUsers) throws Exception {
-        assertNotNull("KDC is null, was setup method called?", KDC);
+        assertNotNull(KDC,"KDC is null, was setup method called?");
         NUM_CREATED_USERS = numUsers;
         for (int i = 1; i <= numUsers; i++) {
             String principal = "user" + i;
@@ -190,10 +190,10 @@ public class QueryServerEnvironment {
             if (f.isDirectory()) {
                 FileUtils.deleteDirectory(f);
             } else {
-                assertTrue("Failed to delete keytab directory", f.delete());
+                assertTrue(f.delete(),"Failed to delete keytab directory");
             }
         }
-        assertTrue("Failed to create keytab directory", f.mkdirs());
+        assertTrue(f.mkdirs(),"Failed to create keytab directory");
     }
 
     /**

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/SecureQueryServerIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/SecureQueryServerIT.java
@@ -16,43 +16,34 @@
  */
 package org.apache.phoenix.end2end;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.security.PrivilegedExceptionAction;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.util.Arrays;
 import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
 import org.apache.hadoop.hbase.security.token.TokenProvider;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(Parameterized.class)
-@Category(NeedsOwnMiniClusterTest.class)
+@Tag("NeedsOwnMiniClusterTest")
 public class SecureQueryServerIT {
     private static final Logger LOG = LoggerFactory.getLogger(SecureQueryServerIT.class);
     private static QueryServerEnvironment environment;
 
-    @Parameters(name = "tls = {0}")
-    public static synchronized Iterable<Boolean> data() {
-        return Arrays.asList(new Boolean[] {false, true});
-    }
-
-    public SecureQueryServerIT(Boolean tls) throws Exception {
+    public void restartEnvironmentForTls(Boolean tls) throws Exception {
         //Clean up previous environment if any (Junit 4.13 @BeforeParam / @AfterParam would be an alternative)
         if(environment != null) {
             stopEnvironment();
@@ -65,13 +56,15 @@ public class SecureQueryServerIT {
     }
 
 
-    @AfterClass
+    @AfterAll
     public static synchronized void stopEnvironment() throws Exception {
         environment.stop();
     }
 
-    @Test
-    public void testBasicReadWrite() throws Exception {
+    @ParameterizedTest(name = "tls = {0}")
+    @ValueSource(booleans = { false, true })
+    public void testBasicReadWrite(Boolean tls) throws Exception {
+        restartEnvironmentForTls(tls);
         final Entry<String,File> user1 = environment.getUser(1);
         UserGroupInformation user1Ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(user1.getKey(), user1.getValue().getAbsolutePath());
         user1Ugi.doAs(new PrivilegedExceptionAction<Void>() {

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/SecureQueryServerPhoenixDBIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/SecureQueryServerPhoenixDBIT.java
@@ -17,9 +17,9 @@
 package org.apache.phoenix.end2end;
 
 import static org.apache.hadoop.hbase.HConstants.HBASE_DIR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -62,12 +62,11 @@ import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.queryserver.server.QueryServer;
 import org.apache.phoenix.util.InstanceResolver;
 import org.apache.phoenix.util.ThinClientUtil;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +74,7 @@ import org.slf4j.LoggerFactory;
  * This integration test stands up a secured PQS and runs Python code against it. See supporting
  * files in phoenix-queryserver/src/it/bin.
  */
-@Category(NeedsOwnMiniClusterTest.class)
+@Tag("NeedsOwnMiniClusterTest")
 public class SecureQueryServerPhoenixDBIT {
     private static enum Kdc {
       MIT,
@@ -120,7 +119,7 @@ public class SecureQueryServerPhoenixDBIT {
     }
 
     private static void createUsers(int numUsers) throws Exception {
-        assertNotNull("KDC is null, was setup method called?", KDC);
+        assertNotNull(KDC, "KDC is null, was setup method called?");
         NUM_CREATED_USERS = numUsers;
         for (int i = 1; i <= numUsers; i++) {
             String principal = "user" + i;
@@ -170,10 +169,10 @@ public class SecureQueryServerPhoenixDBIT {
             if (f.isDirectory()) {
                 FileUtils.deleteDirectory(f);
             } else {
-                assertTrue("Failed to delete keytab directory", f.delete());
+                assertTrue(f.delete(), "Failed to delete keytab directory");
             }
         }
-        assertTrue("Failed to create keytab directory", f.mkdirs());
+        assertTrue(f.mkdirs(), "Failed to create keytab directory");
     }
 
     /**
@@ -191,13 +190,13 @@ public class SecureQueryServerPhoenixDBIT {
         while (processError.ready()) {
             LOG.error(processError.readLine());
         }
-        Assume.assumeTrue("Could not find '" + command + "' on the PATH", exitCode == 0);
+        Assumptions.assumeTrue( exitCode == 0,"Could not find '" + command + "' on the PATH");
     }
 
     /**
      * Setup and start kerberos, hbase
      */
-    @BeforeClass
+    @BeforeAll
     public static synchronized void setUp() throws Exception {
         checkForCommandOnPath("python");
         checkForCommandOnPath("virtualenv");
@@ -306,7 +305,7 @@ public class SecureQueryServerPhoenixDBIT {
         PQS_URL = ThinClientUtil.getConnectionUrl("localhost", PQS_PORT) + ";authentication=SPNEGO";
     }
 
-    @AfterClass
+    @AfterAll
     public static synchronized void stopKdc() throws Exception {
         // Remove our custom ConfigurationFactory for future tests
         InstanceResolver.clearSingletons();
@@ -338,7 +337,7 @@ public class SecureQueryServerPhoenixDBIT {
     //This takes about 300s, so we are not running this by default
     @Test
     public void testFullSuite() throws Exception {
-        Assume.assumeNotNull(System.getProperty("run.full.python.testsuite"));
+        Assumptions.assumeTrue(System.getProperty("run.full.python.testsuite") != null);
         File file = new File(".");
         runShellScript("python", "-m", "unittest", "discover", "-v",  "-s", Paths.get(file.getAbsolutePath(), "..","python-phoenixdb").toString());
     }
@@ -350,7 +349,7 @@ public class SecureQueryServerPhoenixDBIT {
     //and set the environment so that the python unit tests can run against this instance.
     //You'll need to kill the test manually
     public void startLocalPQS() throws Exception {
-        Assume.assumeNotNull(System.getProperty("start.secure.pqs"));
+        Assumptions.assumeTrue(System.getProperty("start.secure.pqs") != null);
         runShellScript("sleep", "86400");
     }
 
@@ -457,7 +456,7 @@ public class SecureQueryServerPhoenixDBIT {
           if (krb5ConfFile != null)
               krb5ConfFile.delete();
 
-          assertEquals("Subprocess exited with errors", 0, exitCode);
+          assertEquals(0, exitCode, "Subprocess exited with errors");
         } finally {
           LOG.info("Test exiting");
           if (outWriter != null) {

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/ServerCustomizersIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/end2end/ServerCustomizersIT.java
@@ -30,12 +30,10 @@ import org.apache.phoenix.queryserver.server.customizers.BasicAuthenticationServ
 import org.apache.phoenix.queryserver.server.customizers.BasicAuthenticationServerCustomizer.BasicAuthServerCustomizerFactory;
 import org.apache.phoenix.util.InstanceResolver;
 import org.apache.phoenix.util.ReadOnlyProps;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +43,7 @@ public class ServerCustomizersIT extends BaseTest {
 
     private static QueryServerTestUtil PQS_UTIL;
 
-    @Rule
-    public ExpectedException expected = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static synchronized void setup() throws Exception {
         setUpTestDriver(ReadOnlyProps.EMPTY_PROPS);
 
@@ -64,7 +59,7 @@ public class ServerCustomizersIT extends BaseTest {
         PQS_UTIL.startQueryServer();
     }
 
-    @AfterClass
+    @AfterAll
     public static synchronized void teardown() throws Exception {
         // Remove custom singletons for future tests
         InstanceResolver.clearSingletons();
@@ -79,21 +74,22 @@ public class ServerCustomizersIT extends BaseTest {
         try (Connection conn = DriverManager.getConnection(PQS_UTIL.getUrl(
                 getBasicAuthParams(BasicAuthenticationServerCustomizer.USER_AUTHORIZED)));
                 Statement stmt = conn.createStatement()) {
-            Assert.assertFalse("user3 should have access", stmt.execute(
-                "create table "+ServerCustomizersIT.class.getSimpleName()+" (pk integer not null primary key)"));
+            assertFalse(stmt.execute(
+                "create table "+ServerCustomizersIT.class.getSimpleName()+" (pk integer not null primary key)"),
+                    "user3 should have access");
         }
     }
 
     @Test
-    public void testUserNotAuthorized() throws Exception {
-        expected.expect(RuntimeException.class);
-        expected.expectMessage("HTTP/401");
-        try (Connection conn = DriverManager.getConnection(PQS_UTIL.getUrl(
-                getBasicAuthParams(USER_NOT_AUTHORIZED)));
-                Statement stmt = conn.createStatement()) {
-            Assert.assertFalse(stmt.execute(
-                    "select access from database"));
-        }
+    void testUserNotAuthorized() {
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            try (Connection conn = DriverManager.getConnection(PQS_UTIL.getUrl(
+                    getBasicAuthParams(USER_NOT_AUTHORIZED)));
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("select access from database");
+            }
+        });
+        assertTrue(ex.getMessage().contains("HTTP/401"));
     }
 
     private Map<String, String> getBasicAuthParams(String user) {

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/tool/ParameterizedPhoenixCanaryToolIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/tool/ParameterizedPhoenixCanaryToolIT.java
@@ -19,7 +19,6 @@ package org.apache.phoenix.tool;
 
 import com.google.gson.Gson;
 
-import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.util.ReadOnlyProps;
@@ -93,9 +92,13 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 		String createTable;
 		cmd.clear();
 
-		if(needsNewCluster(isNamespaceEnabled)) {
-			setClientSideNamespaceProperties(isNamespaceEnabled);
-			setServerSideNamespaceProperties(isNamespaceEnabled);
+        this.isPositiveTestType = isPositiveTestType;
+        this.isNamespaceEnabled = isNamespaceEnabled;
+        this.resultSinkOption = resultSinkOption;
+
+		if(needsNewCluster()) {
+			setClientSideNamespaceProperties();
+			setServerSideNamespaceProperties();
 			tearDownMiniCluster(NUM_SLAVES_BASE);
 			System.setProperty("java.io.tmpdir", tmpDir);
 			// FIXME no idea why java.io.tmpdir gets deleted. We don't see this behaviour in 
@@ -105,14 +108,14 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 			setUpTestDriver(new ReadOnlyProps(serverProps.entrySet().iterator()),
 					new ReadOnlyProps(clientProps.entrySet().iterator()));
 			LOGGER.info("New cluster is spinned up with test parameters " +
-					"isPositiveTestType" + isPositiveTestType +
-					"isNamespaceEnabled" + isNamespaceEnabled +
-					"resultSinkOption" + resultSinkOption);
+					"isPositiveTestType " + this.isPositiveTestType +
+					"isNamespaceEnabled " + this.isNamespaceEnabled +
+					"resultSinkOption " + this.resultSinkOption);
 			connString = BaseTest.getUrl();
-			connection = getConnection(isNamespaceEnabled);
+			connection = getConnection();
 		}
 
-		if (isNamespaceEnabled) {
+		if (this.isNamespaceEnabled) {
 			createSchema = "CREATE SCHEMA IF NOT EXISTS TEST";
 			connection.createStatement().execute(createSchema);
 		}
@@ -123,8 +126,8 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 		cmd.add("--constring");
 		cmd.add(connString);
 		cmd.add("--logsinkclass");
-		cmd.add(resultSinkOption);
-		if (resultSinkOption.contains(stdOutSink)) {
+		cmd.add(this.resultSinkOption);
+		if (this.resultSinkOption.contains(stdOutSink)) {
 			out.reset();
 			System.setOut(new java.io.PrintStream(out));
 		} else {
@@ -132,41 +135,41 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 		}
 	}
 
-	private boolean needsNewCluster(Boolean isNamespaceEnabled) {
+	private boolean needsNewCluster() {
 		if (connection == null) {
 			return true;
 		}
 		if (!clientProps.get(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE)
-				.equalsIgnoreCase(String.valueOf(isNamespaceEnabled))) {
+				.equalsIgnoreCase(String.valueOf(this.isNamespaceEnabled))) {
 			return true;
 		}
 		return false;
 	}
 
-	private void setClientSideNamespaceProperties(Boolean isNamespaceEnabled) {
+	private void setClientSideNamespaceProperties() {
 
 		clientProps.put(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 
 		clientProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 	}
 
-	private Connection getConnection(Boolean isNamespaceEnabled) throws SQLException {
+	private Connection getConnection() throws SQLException {
 		Properties props = new Properties();
 		props.setProperty(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 
 		props.setProperty(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 		return DriverManager.getConnection(connString, props);
 	}
 
-	void setServerSideNamespaceProperties(Boolean isNamespaceEnabled) {
+	void setServerSideNamespaceProperties() {
 		serverProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 		serverProps.put(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(isNamespaceEnabled));
+				String.valueOf(this.isNamespaceEnabled));
 	}
 
 	/*
@@ -180,9 +183,6 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 	public void phoenixCanaryToolTest(
             Boolean isPositiveTestType, Boolean isNamespaceEnabled, String resultSinkOption) throws SQLException, IOException {
         // Per-invocation state for @AfterEach (replaces JUnit 4 parameterized constructor)
-        this.isPositiveTestType = isPositiveTestType;
-        this.isNamespaceEnabled = isNamespaceEnabled;
-        this.resultSinkOption = resultSinkOption;
         try{
             setup(isPositiveTestType, isNamespaceEnabled, resultSinkOption);
         } catch (Exception e) {

--- a/phoenix-queryserver-it/src/it/java/org/apache/phoenix/tool/ParameterizedPhoenixCanaryToolIT.java
+++ b/phoenix-queryserver-it/src/it/java/org/apache/phoenix/tool/ParameterizedPhoenixCanaryToolIT.java
@@ -23,12 +23,11 @@ import org.apache.phoenix.end2end.NeedsOwnMiniClusterTest;
 import org.apache.phoenix.query.BaseTest;
 import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.util.ReadOnlyProps;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,19 +41,18 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import static org.apache.phoenix.tool.PhoenixCanaryTool.propFileName;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
-@Category(NeedsOwnMiniClusterTest.class)
+@Tag("NeedsOwnMiniClusterTest")
 public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 
 	private static final Logger LOGGER =
@@ -76,36 +74,28 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 	private ByteArrayOutputStream out = new ByteArrayOutputStream();
     private String tmpDir = System.getProperty("java.io.tmpdir");
 
-	public ParameterizedPhoenixCanaryToolIT(boolean isPositiveTestType,
-			boolean isNamespaceEnabled, String resultSinkOption) {
-		this.isPositiveTestType = isPositiveTestType;
-		this.isNamespaceEnabled = isNamespaceEnabled;
-		this.resultSinkOption = resultSinkOption;
-	}
+    public static Stream<Arguments> parametersList() {
+        return Stream.of(
+                Arguments.arguments(true, true, stdOutSink),
+                Arguments.arguments(true, true, fileOutSink),
+                Arguments.arguments(false, true, stdOutSink),
+                Arguments.arguments(false, true, fileOutSink),
+                Arguments.arguments(true, false, stdOutSink),
+                Arguments.arguments(true, false, fileOutSink),
+                Arguments.arguments(false, false, stdOutSink),
+                Arguments.arguments(false, false, fileOutSink)
+        );
+    }
 
-	@Parameterized.Parameters(name = "ParameterizedPhoenixCanaryToolIT_isPositiveTestType={0}," +
-			"isNamespaceEnabled={1},resultSinkOption={2}")
-	public static Collection parametersList() {
-		return Arrays.asList(new Object[][] {
-			{true, true, stdOutSink},
-			{true, true, fileOutSink},
-			{false, true, stdOutSink},
-			{false, true, fileOutSink},
-			{true, false, stdOutSink},
-			{true, false, fileOutSink},
-			{false, false, stdOutSink},
-			{false, false, fileOutSink}
-		});
-	}
-
-	@Before
-	public void setup() throws Exception {
+	public void setup(
+            Boolean isPositiveTestType, Boolean isNamespaceEnabled, String resultSinkOption) throws Exception {
 		String createSchema;
 		String createTable;
+		cmd.clear();
 
-		if(needsNewCluster()) {
-			setClientSideNamespaceProperties();
-			setServerSideNamespaceProperties();
+		if(needsNewCluster(isNamespaceEnabled)) {
+			setClientSideNamespaceProperties(isNamespaceEnabled);
+			setServerSideNamespaceProperties(isNamespaceEnabled);
 			tearDownMiniCluster(NUM_SLAVES_BASE);
 			System.setProperty("java.io.tmpdir", tmpDir);
 			// FIXME no idea why java.io.tmpdir gets deleted. We don't see this behaviour in 
@@ -115,14 +105,14 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 			setUpTestDriver(new ReadOnlyProps(serverProps.entrySet().iterator()),
 					new ReadOnlyProps(clientProps.entrySet().iterator()));
 			LOGGER.info("New cluster is spinned up with test parameters " +
-					"isPositiveTestType" + this.isPositiveTestType +
-					"isNamespaceEnabled" + this.isNamespaceEnabled +
-					"resultSinkOption" + this.resultSinkOption);
+					"isPositiveTestType" + isPositiveTestType +
+					"isNamespaceEnabled" + isNamespaceEnabled +
+					"resultSinkOption" + resultSinkOption);
 			connString = BaseTest.getUrl();
-			connection = getConnection();
+			connection = getConnection(isNamespaceEnabled);
 		}
 
-		if (this.isNamespaceEnabled) {
+		if (isNamespaceEnabled) {
 			createSchema = "CREATE SCHEMA IF NOT EXISTS TEST";
 			connection.createStatement().execute(createSchema);
 		}
@@ -133,49 +123,50 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 		cmd.add("--constring");
 		cmd.add(connString);
 		cmd.add("--logsinkclass");
-		cmd.add(this.resultSinkOption);
-		if (this.resultSinkOption.contains(stdOutSink)) {
+		cmd.add(resultSinkOption);
+		if (resultSinkOption.contains(stdOutSink)) {
+			out.reset();
 			System.setOut(new java.io.PrintStream(out));
 		} else {
 			loadCanaryPropertiesFile(canaryProp);
 		}
 	}
 
-	private boolean needsNewCluster() {
+	private boolean needsNewCluster(Boolean isNamespaceEnabled) {
 		if (connection == null) {
 			return true;
 		}
 		if (!clientProps.get(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE)
-				.equalsIgnoreCase(String.valueOf(this.isNamespaceEnabled))) {
+				.equalsIgnoreCase(String.valueOf(isNamespaceEnabled))) {
 			return true;
 		}
 		return false;
 	}
 
-	private void setClientSideNamespaceProperties() {
+	private void setClientSideNamespaceProperties(Boolean isNamespaceEnabled) {
 
 		clientProps.put(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 
 		clientProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 	}
 
-	private Connection getConnection() throws SQLException {
+	private Connection getConnection(Boolean isNamespaceEnabled) throws SQLException {
 		Properties props = new Properties();
 		props.setProperty(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 
 		props.setProperty(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 		return DriverManager.getConnection(connString, props);
 	}
 
-	void setServerSideNamespaceProperties() {
+	void setServerSideNamespaceProperties(Boolean isNamespaceEnabled) {
 		serverProps.put(QueryServices.IS_NAMESPACE_MAPPING_ENABLED,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 		serverProps.put(QueryServices.IS_SYSTEM_TABLE_MAPPED_TO_NAMESPACE,
-				String.valueOf(this.isNamespaceEnabled));
+				String.valueOf(isNamespaceEnabled));
 	}
 
 	/*
@@ -184,8 +175,19 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 	*	It tests the tool in positive type where test expects to pass
 	*	and negative type where test expects to fail.
  	*/
-	@Test
-	public void phoenixCanaryToolTest() throws SQLException, IOException {
+    @ParameterizedTest(name = "isPositiveTestType={0}, isNamespaceEnabled={1}, resultSinkOption={2}")
+    @MethodSource("parametersList")
+	public void phoenixCanaryToolTest(
+            Boolean isPositiveTestType, Boolean isNamespaceEnabled, String resultSinkOption) throws SQLException, IOException {
+        // Per-invocation state for @AfterEach (replaces JUnit 4 parameterized constructor)
+        this.isPositiveTestType = isPositiveTestType;
+        this.isNamespaceEnabled = isNamespaceEnabled;
+        this.resultSinkOption = resultSinkOption;
+        try{
+            setup(isPositiveTestType, isNamespaceEnabled, resultSinkOption);
+        } catch (Exception e) {
+            fail("Error during setup" + e.getMessage());
+        }
 		if (!isPositiveTestType) {
 			dropTestTable();
 		}
@@ -232,14 +234,17 @@ public class ParameterizedPhoenixCanaryToolIT extends BaseTest {
 		return files[0];
 	}
 
-	@After
+	@AfterEach
 	public void teardown() throws SQLException {
+		if (connection == null) {
+			return;
+		}
 		if (this.isNamespaceEnabled) {
 			dropTestTableAndSchema();
 		} else {
 			dropTestTable();
 		}
-		if (this.resultSinkOption.contains(fileOutSink)) {
+		if (this.resultSinkOption != null && this.resultSinkOption.contains(fileOutSink)) {
 			deleteResultSinkFile();
 		}
 	}

--- a/phoenix-queryserver-load-balancer/pom.xml
+++ b/phoenix-queryserver-load-balancer/pom.xml
@@ -71,6 +71,9 @@
               <ignoredUnusedDeclaredDependency>
                 org.slf4j:slf4j-api
               </ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>
+                org.junit.jupiter:junit-jupiter-engine
+              </ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
       </plugin>
@@ -126,11 +129,17 @@
     </dependency>
 
     <!-- for tests -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>

--- a/phoenix-queryserver-load-balancer/src/it/java/org/apache/phoenix/end2end/LoadBalancerEnd2EndIT.java
+++ b/phoenix-queryserver-load-balancer/src/it/java/org/apache/phoenix/end2end/LoadBalancerEnd2EndIT.java
@@ -31,12 +31,19 @@ import org.apache.phoenix.queryserver.register.Registry;
 import org.apache.phoenix.queryserver.register.ZookeeperRegistry;
 import org.apache.phoenix.util.HostAndPort;
 import org.apache.zookeeper.KeeperException;
-import org.junit.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+
 
 public class LoadBalancerEnd2EndIT {
     private static TestingServer testingServer;
@@ -51,7 +58,7 @@ public class LoadBalancerEnd2EndIT {
     public static String zkConnectString;
     public static Registry registry;
 
-    @BeforeClass
+    @BeforeAll
     public static synchronized void setup() throws Exception{
 
         registry = new ZookeeperRegistry();
@@ -69,7 +76,7 @@ public class LoadBalancerEnd2EndIT {
         loadBalancer = LoadBalancer.getLoadBalancer();
     }
 
-    @AfterClass
+    @AfterAll
     public static synchronized void tearDown() throws Exception {
         CloseableUtils.closeQuietly(curatorFramework);
         CloseableUtils.closeQuietly(testingServer);
@@ -85,58 +92,62 @@ public class LoadBalancerEnd2EndIT {
 
     @Test
     public void testGetAllServiceLocation() throws Exception {
-        Assert.assertNotNull(loadBalancer);
+        assertNotNull(loadBalancer);
         List<HostAndPort> serviceLocations = loadBalancer.getAllServiceLocation();
-        Assert.assertTrue(" must contains 3 service location",serviceLocations.size() == 3);
+        assertSame(3, serviceLocations.size(), " must contains 3 service location");
     }
 
     @Test
     public void testGetSingleServiceLocation() throws Exception {
-        Assert.assertNotNull(loadBalancer);
+        assertNotNull(loadBalancer);
         HostAndPort serviceLocation = loadBalancer.getSingleServiceLocation();
-        Assert.assertNotNull(serviceLocation);
+        assertNotNull(serviceLocation);
     }
 
-    @Test(expected=Exception.class)
-    public void testZookeeperDown() throws Exception{
-       testingServer.stop();
-       CuratorZookeeperClient zookeeperClient =  curatorFramework.getZookeeperClient();
-        //check to see if zookeeper is really down.
-       while (zookeeperClient.isConnected()){
-            Thread.sleep(1000);
-       };
-       loadBalancer.getSingleServiceLocation();
-    }
-
-    @Test(expected = KeeperException.NoNodeException.class)
-    public void testNoPhoenixQueryServerNodeInZookeeper() throws Exception{
-        List<HostAndPort> hostAndPorts = Arrays.asList(pqs1, pqs2, pqs3);
-        for(HostAndPort pqs: hostAndPorts) {
-            String fullPathToNode = LOAD_BALANCER_CONFIGURATION.getFullPathToNode(pqs);
-            curatorFramework.delete().deletingChildrenIfNeeded().forPath(fullPathToNode);
-            while (curatorFramework.checkExists().forPath(fullPathToNode) != null){
-                //wait for the node to deleted
+    @Test
+    public void testZookeeperDown() {
+       assertThrows(Exception.class, () -> {
+           testingServer.stop();
+           CuratorZookeeperClient zookeeperClient =  curatorFramework.getZookeeperClient();
+            //check to see if zookeeper is really down.
+           while (zookeeperClient.isConnected()){
                 Thread.sleep(1000);
-            };
-        }
-        //delete the parent
-        curatorFramework.delete().forPath(path);
-        // should throw an exception as there is
-        // no node in the zookeeper
-        try {
-            loadBalancer.getSingleServiceLocation();
-        } catch(Exception e) {
-            throw e;
-        } finally {
-            // need to create node for other tests to run.
-            createNodeForTesting(hostAndPorts);
-        }
+           };
+           loadBalancer.getSingleServiceLocation();
+       });
+    }
+
+    @Test
+    public void testNoPhoenixQueryServerNodeInZookeeper() {
+        assertThrows(KeeperException.NoNodeException.class, () -> {
+            List<HostAndPort> hostAndPorts = Arrays.asList(pqs1, pqs2, pqs3);
+            for(HostAndPort pqs: hostAndPorts) {
+                String fullPathToNode = LOAD_BALANCER_CONFIGURATION.getFullPathToNode(pqs);
+                curatorFramework.delete().deletingChildrenIfNeeded().forPath(fullPathToNode);
+                while (curatorFramework.checkExists().forPath(fullPathToNode) != null){
+                    //wait for the node to deleted
+                    Thread.sleep(1000);
+                };
+            }
+            //delete the parent
+            curatorFramework.delete().forPath(path);
+            // should throw an exception as there is
+            // no node in the zookeeper
+            try {
+                loadBalancer.getSingleServiceLocation();
+            } catch(Exception e) {
+                throw e;
+            } finally {
+                // need to create node for other tests to run.
+                createNodeForTesting(hostAndPorts);
+            }
+        });
     }
 
     @Test
     public void testSingletonPropertyForLoadBalancer(){
         LoadBalancer anotherloadBalancerRef = LoadBalancer.getLoadBalancer();
-        Assert.assertTrue(" the load balancer is not singleton",loadBalancer == anotherloadBalancerRef );
+        assertSame(loadBalancer, anotherloadBalancerRef, " the load balancer is not singleton");
     }
 
 

--- a/phoenix-queryserver-load-balancer/src/test/java/org/apache/phoenix/loadbalancer/service/LoadBalanceZookeeperConfImplTest.java
+++ b/phoenix-queryserver-load-balancer/src/test/java/org/apache/phoenix/loadbalancer/service/LoadBalanceZookeeperConfImplTest.java
@@ -21,8 +21,9 @@ package org.apache.phoenix.loadbalancer.service;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.phoenix.queryserver.QueryServerProperties;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class LoadBalanceZookeeperConfImplTest {
     @Test
@@ -48,12 +49,12 @@ public class LoadBalanceZookeeperConfImplTest {
         final LoadBalanceZookeeperConfImpl loadBalanceZookeeperConf = new LoadBalanceZookeeperConfImpl(conf);
         String[] connectStrings = loadBalanceZookeeperConf.getZkConnectString().split(",");
         String[] quorums = quorum.split(",");
-        Assert.assertTrue( connectStrings.length == quorums.length);
+        assertTrue( connectStrings.length == quorums.length);
         for (int i = 0; i< connectStrings.length; ++i) {
             if (quorums[i].contains(":")) {
-                Assert.assertEquals(quorums[i], connectStrings[i]);
+                assertEquals(quorums[i], connectStrings[i]);
             } else {
-                Assert.assertEquals(quorums[i] + ":" + port, connectStrings[i]);
+                assertEquals(quorums[i] + ":" + port, connectStrings[i]);
             }
         }
     }

--- a/phoenix-queryserver-orchestrator/pom.xml
+++ b/phoenix-queryserver-orchestrator/pom.xml
@@ -48,6 +48,9 @@
             <ignoredUnusedDeclaredDependency>
               org.apache.hbase:hbase-it
             </ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>
+              org.junit.jupiter:junit-jupiter-engine
+            </ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <!-- dependency:analyze is quite useless for hadoop test dependencies -->
           <ignoreNonCompile>true</ignoreNonCompile>
@@ -95,11 +98,17 @@
             <artifactId>gson</artifactId>
         </dependency>
         <!-- test -->
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+    </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/phoenix-queryserver-orchestrator/src/test/java/org/apache/phoenix/tool/PhoenixCanaryToolTest.java
+++ b/phoenix-queryserver-orchestrator/src/test/java/org/apache/phoenix/tool/PhoenixCanaryToolTest.java
@@ -17,10 +17,12 @@
  */
 package org.apache.phoenix.tool;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
@@ -48,7 +50,7 @@ public class PhoenixCanaryToolTest {
     @Mock
     private DatabaseMetaData dbm;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }
@@ -59,7 +61,7 @@ public class PhoenixCanaryToolTest {
         when(connection.prepareStatement(Mockito.anyString())).thenReturn(ps);
         when(statement.executeUpdate(Mockito.anyString())).thenReturn(1);
         CanaryTestResult result = new PhoenixCanaryTool.UpsertTableTest().runTest(connection);
-        assertEquals(true, result.isSuccessful());
+        assertTrue(result.isSuccessful());
         assertEquals("Test upsertTable successful", result.getMessage());
     }
 
@@ -71,7 +73,7 @@ public class PhoenixCanaryToolTest {
         when(rs.getInt(1)).thenReturn(1);
         when(rs.getString(2)).thenReturn("Hello World");
         CanaryTestResult result = new PhoenixCanaryTool.ReadTableTest().runTest(connection);
-        assertEquals(true, result.isSuccessful());
+        assertTrue(result.isSuccessful());
         assertEquals("Test readTable successful", result.getMessage());
     }
 
@@ -83,7 +85,7 @@ public class PhoenixCanaryToolTest {
         when(rs.getString(2)).thenReturn("Incorrect data");
         when(rs.next()).thenReturn(true).thenReturn(false);
         CanaryTestResult result = new PhoenixCanaryTool.ReadTableTest().runTest(connection);
-        assertEquals(false, result.isSuccessful());
+        assertFalse(result.isSuccessful());
         assert (result.getMessage().contains("Retrieved values do not match the inserted values"));
     }
 }

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -74,6 +74,10 @@
             <ignoredUnusedDeclaredDependency>
               org.slf4j:slf4j-api
             </ignoredUnusedDeclaredDependency>
+            <!-- Required at test runtime by Surefire; not imported from test sources -->
+            <ignoredUnusedDeclaredDependency>
+              org.junit.jupiter:junit-jupiter-engine
+            </ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
@@ -229,6 +233,12 @@
     <dependency>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix-queryserver-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -232,8 +232,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/DriverCohabitationTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/DriverCohabitationTest.java
@@ -19,16 +19,16 @@ package org.apache.phoenix;
 
 import org.apache.phoenix.util.QueryUtil;
 import org.apache.phoenix.util.ThinClientUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Ensure the "thick" Phoenix driver and it's "thin" counterpart can coexist on
@@ -48,18 +48,14 @@ public class DriverCohabitationTest {
         thinDriver = d;
       }
     }
-    assertNotNull("Thick driver not registered with DriverManager.", thickDriver);
-    assertNotNull("Thin driver not registered with DriverManager.", thinDriver);
+    assertNotNull(thickDriver,"Thick driver not registered with DriverManager.");
+    assertNotNull(thinDriver,"Thin driver not registered with DriverManager.");
 
     final String thickUrl = QueryUtil.getUrl("localhost");
     final String thinUrl = ThinClientUtil.getConnectionUrl("localhost", 1234);
-    assertTrue("Thick driver should accept connections like " + thickUrl,
-        thickDriver.acceptsURL(thickUrl));
-    assertFalse("Thick driver should reject connections like " + thinUrl,
-        thickDriver.acceptsURL(thinUrl));
-    assertTrue("Thin driver should accept connections like " + thinUrl,
-        thinDriver.acceptsURL(thinUrl));
-    assertFalse("Thin driver should reject connections like " + thickUrl,
-        thinDriver.acceptsURL(thickUrl));
+    assertTrue(thickDriver.acceptsURL(thickUrl), "Thick driver should accept connections like " + thickUrl);
+    assertFalse(thickDriver.acceptsURL(thinUrl),"Thick driver should reject connections like " + thinUrl);
+    assertTrue(thinDriver.acceptsURL(thinUrl),"Thin driver should accept connections like " + thinUrl);
+    assertFalse(thinDriver.acceptsURL(thickUrl),"Thin driver should reject connections like " + thickUrl);
   }
 }

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/CustomAvaticaServerConfigurationTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/CustomAvaticaServerConfigurationTest.java
@@ -20,8 +20,8 @@ package org.apache.phoenix.queryserver.server;
 import org.apache.calcite.avatica.server.AvaticaServerConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -32,6 +32,6 @@ public class CustomAvaticaServerConfigurationTest {
         UserGroupInformation ugi = queryServer.getUserGroupInformation();
         // the default factory creates null object
         AvaticaServerConfiguration avaticaServerConfiguration = queryServer.createAvaticaServerConfig(new Configuration(), ugi);
-        Assert.assertNull(avaticaServerConfiguration);
+        assertNull(avaticaServerConfiguration);
     }
 }

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/PhoenixDoAsCallbackTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/PhoenixDoAsCallbackTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.phoenix.queryserver.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.Callable;
 
@@ -26,7 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.phoenix.queryserver.server.QueryServer.PhoenixDoAsCallback;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the authorization callback hook Avatica provides for Phoenix to implement.
@@ -83,7 +83,7 @@ public class PhoenixDoAsCallbackTest {
       // The UserGroupInformation.getCurrentUser() actually returns a new UGI instance, but the internal
       // subject is the same. We can verify things will work as expected that way.
       assertNotEquals(user1.hashCode(), user2.hashCode());
-      assertEquals("These should be the same (cached) instance", user1.hashCode(), user1Reference.hashCode());
-      assertEquals("These should be the same (cached) instance", user1, user1Reference);
+      assertEquals(user1.hashCode(), user1Reference.hashCode(), "These should be the same (cached) instance");
+      assertEquals(user1, user1Reference, "These should be the same (cached) instance");
     }
 }

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/PhoenixRemoteUserExtractorTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/PhoenixRemoteUserExtractorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.phoenix.queryserver.server;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -31,7 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.queryserver.server.QueryServer.PhoenixRemoteUserExtractor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerConfigurationTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.calcite.avatica.server.AvaticaServerConfiguration;
 import org.apache.calcite.avatica.server.DoAsRemoteUserCallback;
@@ -35,21 +36,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.phoenix.queryserver.QueryServerProperties;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Test;
 
 public class QueryServerConfigurationTest {
   private static final Configuration CONF = HBaseConfiguration.create();
 
-  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+  @TempDir
+  public Path testFolder;
 
   private HttpServer.Builder builder;
   private QueryServer queryServer;
   private UserGroupInformation ugi;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     builder = mock(HttpServer.Builder.class);
     queryServer = new QueryServer(new String[0], CONF);
@@ -86,7 +87,7 @@ public class QueryServerConfigurationTest {
   }
 
   private void setupKeytabForSpnego() throws IOException {
-    File keytabFile = testFolder.newFile("test.keytab");
+    File keytabFile = testFolder.resolve("test.keytab").toFile();
     CONF.set(QueryServerProperties.QUERY_SERVER_KEYTAB_FILENAME_ATTRIB, keytabFile.getAbsolutePath());
   }
 

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/QueryServerTest.java
@@ -17,16 +17,16 @@
  */
 package org.apache.phoenix.queryserver.server;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.InetAddress;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.phoenix.queryserver.QueryServerProperties;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class QueryServerTest {
 
@@ -38,12 +38,12 @@ public class QueryServerTest {
   private QueryServer qs;
   private Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupOnce() throws IOException {
     EXPECTED_HOSTNAME = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase();
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.conf = new Configuration(false);
     this.qs = new QueryServer();

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/RemoteUserExtractorFactoryTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/RemoteUserExtractorFactoryTest.java
@@ -19,8 +19,8 @@ package org.apache.phoenix.queryserver.server;
 
 import org.apache.calcite.avatica.server.RemoteUserExtractor;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class RemoteUserExtractorFactoryTest {
 
@@ -28,8 +28,7 @@ public class RemoteUserExtractorFactoryTest {
   public void testProvidesDefaultFactory() {
     QueryServer queryServer = new QueryServer();
     RemoteUserExtractor extractor = queryServer.createRemoteUserExtractor(new Configuration());
-    Assert.assertTrue(
-      "Not an instance of PhoenixRemoteUserExtractor: " + extractor.getClass().getName(),
-      extractor instanceof QueryServer.PhoenixRemoteUserExtractor);
+    assertTrue(extractor instanceof QueryServer.PhoenixRemoteUserExtractor,
+            "Not an instance of PhoenixRemoteUserExtractor: " + extractor.getClass().getName());
   }
 }

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/ServerCustomizersTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/ServerCustomizersTest.java
@@ -28,17 +28,17 @@ import org.apache.phoenix.query.QueryServices;
 import org.apache.phoenix.queryserver.QueryServerProperties;
 import org.apache.phoenix.util.InstanceResolver;
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class ServerCustomizersTest {
-    @Before @After
+    @BeforeEach @AfterEach
     public void clearSingletons() {
         // clean up singletons
         InstanceResolver.clearSingletons();
@@ -51,7 +51,7 @@ public class ServerCustomizersTest {
         // the default factory creates an empty list of server customizers
         List<ServerCustomizer<Server>> customizers =
                 queryServer.createServerCustomizers(new Configuration(), avaticaServerConfiguration);
-        Assert.assertEquals(1, customizers.size());
+        assertEquals(1, customizers.size());
     }
 
     @Test
@@ -75,6 +75,6 @@ public class ServerCustomizersTest {
         Configuration conf = new Configuration(false);
         QueryServer queryServer = new QueryServer();
         List<ServerCustomizer<Server>> actual = queryServer.createServerCustomizers(conf, avaticaServerConfiguration);
-        Assert.assertEquals("Customizers are different", expected, actual);
+        assertEquals(expected, actual, "Customizers are different");
     }
 }

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/customizers/HostedClientJarsServerCustomizerTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/server/customizers/HostedClientJarsServerCustomizerTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.phoenix.queryserver.server.customizers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -27,7 +27,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class HostedClientJarsServerCustomizerTest {
@@ -47,7 +47,7 @@ public class HostedClientJarsServerCustomizerTest {
 
     assertEquals(1, svr.getHandlers().length);
     Handler actualHandler = svr.getHandler();
-    assertTrue("Handler was " + actualHandler.getClass(), actualHandler instanceof HandlerList);
+    assertTrue(actualHandler instanceof HandlerList,"Handler was " + actualHandler.getClass());
 
     HandlerList actualHandlerList = (HandlerList) actualHandler;
     assertEquals(3, actualHandlerList.getHandlers().length);
@@ -55,9 +55,9 @@ public class HostedClientJarsServerCustomizerTest {
     assertEquals(handler2, actualHandlerList.getHandlers()[2]);
 
     Handler injectedHandler = actualHandlerList.getHandlers()[0];
-    assertTrue("Handler was " + injectedHandler.getClass(), injectedHandler instanceof ContextHandler);
+    assertTrue(injectedHandler instanceof ContextHandler,"Handler was " + injectedHandler.getClass());
     ContextHandler ctx = (ContextHandler) injectedHandler;
-    assertTrue("Handler was " + ctx.getHandler().getClass(), ctx.getHandler() instanceof ResourceHandler);
+    assertTrue(ctx.getHandler() instanceof ResourceHandler, "Handler was " + ctx.getHandler().getClass());
     assertEquals(context, ctx.getContextPath());
     ResourceHandler res = (ResourceHandler) ctx.getHandler();
     // Jetty puts in a proper URI for the file we give it

--- a/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/util/SimpleLRUCacheTest.java
+++ b/phoenix-queryserver/src/test/java/org/apache/phoenix/queryserver/util/SimpleLRUCacheTest.java
@@ -17,10 +17,10 @@
  */
 package org.apache.phoenix.queryserver.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.phoenix.util.SimpleLRUCache;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleLRUCacheTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,12 +217,6 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <configuration>
-                        <ignoredDependencies>
-                            <ignoredDependency>junit:junit:jar:4.13.2</ignoredDependency>
-                            <ignoredDependency>org.junit.vintage:junit-vintage-engine:jar:5.10.2</ignoredDependency>
-                        </ignoredDependencies>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>enforce-dependencies</id>
@@ -1217,11 +1211,6 @@
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
Sub-task of [PHOENIX-7779](https://issues.apache.org/jira/browse/PHOENIX-7779), updating jUnit to 5.10.2 for [phoenix-queryserver](https://github.com/apache/phoenix-queryserver) all subcomponents.